### PR TITLE
Handles OAuth, UpApi object, and unit tests 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,11 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# Virtualenv
+bin/
+include/
+pip-selfcheck.json
+
+# Pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This SDK provides an object-oriented interface for working with the UP APIs. The
 ### Register your application
 Visit the [UP Developer Portal](https://jawbone.com/up/developer/) and click [Sign In](https://jawbone.com/up/developer/auth/login) to login with your UP account (or to create a new account).
 
-Once you have created your account, you can create a new application by clicking the **Create App** button on your [account page](https://jawbone.com/up/developer/account). Fill out the form with the specific details for your application. If you don't know what to put for the URLs, review the [Authentication documentation](https://jawbone.com/up/developer/authentication).
+Once you have signed in, you can create a new application by clicking the **Create App** button on your [account page](https://jawbone.com/up/developer/account). Fill out the form with the specific details for your application. If you don't know what to put for the URLs, review the [Authentication documentation](https://jawbone.com/up/developer/authentication).
 
 ### Install the SDK
 ***When active development stops, we will put this on pypi. For now, installation is a bit manual.***
@@ -34,11 +34,11 @@ upapi.token_saver = <token_saver>
 
 You can find your **Client Id** and **App Secret** in your Application Details (click on your app in the bottom left of the nav on the UP Developer Portal).
 
-**OAuth redirect URL** must be one of the URLs you specified when creating your application. If you have multiple URLs, you do not need to set this parameter and instead specify a URL when calling ```get_redirect_url```
+**OAuth redirect URL** must be one of the URLs you specified when creating your application. If you have multiple URLs, you do not need to set this parameter; instead, specify a URL when calling ```get_redirect_url```
 
 The ```upapi.scopes``` module provides a list of all the avaialable scopes. You can find scope definitions in the [UP API Authentication documentation](https://jawbone.com/up/developer/authentication).
 
-The SDK can automatically refresh any expired access tokens. To do so, you must provide a **token_saver** function, which the SDK call with the value of the new token. For more details, refer to the [Requests-OAuthlib documentation](http://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow.html#third-recommended-define-automatic-token-refresh-and-update).
+The SDK can automatically refresh any expired access tokens. To do so, you must provide a **token_saver** function, which the SDK will call with the value of the new token. For more details, refer to the [Requests-OAuthlib documentation](http://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow.html#third-recommended-define-automatic-token-refresh-and-update).
 
 ## Authentication
 The UP API uses OAuth2 to grant access to user data. For details, please read the [Authentication documentation](https://jawbone.com/up/developer/authentication).
@@ -75,7 +75,7 @@ upapi.token = <token>
 Note: if this is the same session in which you authenticated this user, the SDK will automatically set the value of ```upapi.token``` when you call ```upapi.get_token```.
 
 #### Refreshing Tokens
-The UP API OAuth2 tokens will expire after one year, so you will need to refresh them.
+The UP API OAuth2 tokens will expire after one year, so you will need to refresh them. The easiest way to do this is to set ```upapi.token_saver```. Then, the SDK will automatically refresh expired tokens. However, you can always manually refresh a token.
 ```python
 upapi.refresh_token()
 ```
@@ -84,12 +84,12 @@ This will use the existing value of ```upapi.token``` to get a new token and the
 #### Disconnecting Users
 In certain instances, you will need to disconnect a user from your application and the UP API. The [Disconnection documentation](https://jawbone.com/up/developer/disconnection) provides details on when and how this can happen.
 ```python
-upapi.disconnect
+upapi.disconnect()
 ```
 This will use the existing value of ```upapi.token``` to send a disconnection request to the API and then clear the value of ```upapi.token```.
 
 ## UpApi
-The SDK creates ```UpApi``` objects to manage the OAuth connection and issue all requests to the UP API. By default, an ```UpApi``` object initializes itself with the global values you have already set in the ```upapi``` module. However, if you want to manage the OAuth connect yourself, you can create your own ```UpApi``` objects.
+The SDK creates ```UpApi``` objects to manage the OAuth connection and issue all requests to the UP API. By default, an ```UpApi``` object initializes itself with the global values you have already set in the ```upapi``` module. However, if you want to manage the OAuth connection yourself, you can create your own ```UpApi``` objects.
 ```python
 up = upapi.UpApi(
   app_id = <Client Id>
@@ -105,7 +105,7 @@ For more details, read the documentation in the code.
 ## What's next?
 The next steps for the SDK will be to add objects to represent each of the [resources in the UP API](https://jawbone.com/up/developer/endpoints).
 
-For now, if you would like to use the SDK, you can establish the OAuth connection according to the instructions above. Then, you can issue requests through the UpApi object's ```oauth``` attribute, which is an instance of ```requests_oauthlib.OAuth2Session```.
+For now, if you would like to use the SDK, you can establish the OAuth connection according to the instructions above. Then, you can issue requests through the ```UpApi``` object's ```oauth``` attribute, which is an instance of ```requests_oauthlib.OAuth2Session```.
 ```python
 up = upapi.UpApi()
 resp = up.oauth.get('https://jawbone.com/nudge/api/v.1.1/users/@me')

--- a/README.md
+++ b/README.md
@@ -1,10 +1,119 @@
 # UPPlatform_Python_SDK
-Python SDK for the UP API
+Python SDK for the [Jawbone UP API](https://jawbone.com/up/developer/)
 
-## Work in progress!
+***The SDK is still under active development, so expect frequent changes.***
+
+This SDK provides an object-oriented interface for working with the UP APIs. The UP APIs provide an OAuth2 workflow for accessing protected resources, so this SDK makes heavy use of the [Requests-OAuthlib](http://requests-oauthlib.readthedocs.io/) package (which makes life super easy).
+
+## Getting Started
+### Register your application
+Visit the [UP Developer Portal](https://jawbone.com/up/developer/) and click [Sign In](https://jawbone.com/up/developer/auth/login) to login with your UP account (or to create a new account).
+
+Once you have created your account, you can create a new application by clicking the **Create App** button on your [account page](https://jawbone.com/up/developer/account). Fill out the form with the specific details for your application. If you don't know what to put for the URLs, review the [Authentication documentation](https://jawbone.com/up/developer/authentication).
+
+### Install the SDK
+***When active development stops, we will put this on pypi. For now, installation is a bit manual.***
+
+1. Download/clone/fork this repository into your application's PYTHONPATH.
+1. Install the dependencies.
+```bash
+pip install -r upapi/requirements.txt
+```
+
+### Initialize the SDK
+```python
+import upapi
+import upapi.scopes
+
+upapi.client_id = <Client Id>
+upapi.client_secret = <App Secret>
+upapi.redirect_uri = <OAuth redirect URL>
+upapi.scope = [upapi.scopes.<Scope0>, upapi.scopes.<Scope1>,...]
+upapi.token_saver = <token_saver>
+```
+
+You can find your **Client Id** and **App Secret** in your Application Details (click on your app in the bottom left of the nav on the UP Developer Portal).
+
+**OAuth redirect URL** must be one of the URLs you specified when creating your application. If you have multiple URLs, you do not need to set this parameter and instead specify a URL when calling ```get_redirect_url```
+
+The ```upapi.scopes``` module provides a list of all the avaialable scopes. You can find scope definitions in the [UP API Authentication documentation](https://jawbone.com/up/developer/authentication).
+
+The SDK can automatically refresh any expired access tokens. To do so, you must provide a **token_saver** function, which the SDK call with the value of the new token. For more details, refer to the [Requests-OAuthlib documentation](http://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow.html#third-recommended-define-automatic-token-refresh-and-update).
+
+## Authentication
+The UP API uses OAuth2 to grant access to user data. For details, please read the [Authentication documentation](https://jawbone.com/up/developer/authentication).
+
+### New Users
+The first thing any application will need to do is have a user authenticate in the UP system and grant access to UP data. With the SDK,  this is a two step process:
+
+1. Redirect the user to an app-specific login screen.
+1. Convert a temporary authorization code into an access token.
+
+#### Redirect to login
+The SDK provides a helper function to generate an application-specific UP login URL.
+```python
+url = upapi.get_redirect_url()
+```
+
+If your application has multiple OAuth redirect URLs, then you can pass one of them as the ```override_url``` parameter of ```get_redirect_url```.
+
+#### Get the access token
+After the user grants access to your application, the UP API redirects the user back to the URL you specified with an **authorization_code**. You then need to exchange this code for an access token. Pass the entire URL to the ```get_token``` function to do this.
+```python
+token = upapi.get_token(url)
+```
+
+### Returning Users
+Once a user has granted your application access to UP data, you can save the access token for re-use on subsequent interactions with the UP API.
+
+#### Set Token
+After you have initialized the SDK according to the instructions above, all you need to do is set the value of the token parameter.
+```python
+upapi.token = <token>
+```
+
+Note: if this is the same session in which you authenticated this user, the SDK will automatically set the value of ```upapi.token``` when you call ```upapi.get_token```.
+
+#### Refreshing Tokens
+The UP API OAuth2 tokens will expire after one year, so you will need to refresh them.
+```python
+upapi.refresh_token()
+```
+This will use the existing value of ```upapi.token``` to get a new token and then set it as the new value of ```upapi.token```.
+
+#### Disconnecting Users
+In certain instances, you will need to disconnect a user from your application and the UP API. The [Disconnection documentation](https://jawbone.com/up/developer/disconnection) provides details on when and how this can happen.
+```python
+upapi.disconnect
+```
+This will use the existing value of ```upapi.token``` to send a disconnection request to the API and then clear the value of ```upapi.token```.
+
+## UpApi
+The SDK creates ```UpApi``` objects to manage the OAuth connection and issue all requests to the UP API. By default, an ```UpApi``` object initializes itself with the global values you have already set in the ```upapi``` module. However, if you want to manage the OAuth connect yourself, you can create your own ```UpApi``` objects.
+```python
+up = upapi.UpApi(
+  app_id = <Client Id>
+  app_secret = <App Secret>
+  app_redirect_uri = <OAuth redirect URL>
+  app_scope = [upapi.scopes.<Scope0>, upapi.scopes.<Scope1>,...]
+  app_token_saver = <token_saver>
+  app_token = <token>)
+```
+
+For more details, read the documentation in the code.
+
+## What's next?
+The next steps for the SDK will be to add objects to represent each of the [resources in the UP API](https://jawbone.com/up/developer/endpoints).
+
+For now, if you would like to use the SDK, you can establish the OAuth connection according to the instructions above. Then, you can issue requests through the UpApi object's ```oauth``` attribute, which is an instance of ```requests_oauthlib.OAuth2Session```.
+```python
+up = upapi.UpApi()
+resp = up.oauth.get('https://jawbone.com/nudge/api/v.1.1/users/@me')
+resp.json()
+```
 
 ## Help!
-If you have questions about the UP API, check out the [docs](https://jawbone.com/up/developer/).
+If you have questions about the SDK or the UP API, check out the [docs](https://jawbone.com/up/developer/).
 
 Can't find the answer, ask a question on [Stack Overflow using the jawbone tag](http://stackoverflow.com/questions/tagged/jawbone)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+coverage==4.1
+funcsigs==1.0.2
+mock==2.0.0
+oauthlib==1.1.2
+pbr==1.10.0
+requests==2.10.0
+requests-oauthlib==0.6.1
+six==1.10.0

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,3 @@
+"""
+Put Unit Tests in here
+"""

--- a/test/test_UpApi.py
+++ b/test/test_UpApi.py
@@ -3,44 +3,70 @@ Unit tests for upapi.__init__
 """
 import unittest
 import upapi
-import urlparse
 
 
-def get_redirect_param(url):
-    """
-    Retrieve the redirect_uri parameter from the URL.
-
-    :param url: URL to parse
-    :return: the redirect_uri param
-    """
-    return urlparse.parse_qs(urlparse.urlparse(url).query)['redirect_uri'][0]
-
-
-class TestGetRedirectUrl(unittest.TestCase):
-    def test_get_redirect_url(self):
+class TestUpApi(unittest.TestCase):
+    def setUp(self):
         """
-        Unit tests for upapi.get_redirect_url
-
-        :return: None
+        Create the UpApi object.
         """
-        #
-        # Explicit redirect_url
-        #
-        url = 'https://explicit.com'
-        redirect_url = upapi.get_redirect_url(app_url=url)
-        self.assertEqual(get_redirect_param(redirect_url), url)
+        upapi.client_id = 'client_id'
+        upapi.client_secret = 'client_secret'
+        upapi.redirect_uri = 'redirect_uri'
+        upapi.scope = ['scope0', 'scope1']
+        self.up = upapi.UpApi()
+        super(TestUpApi, self).setUp()
+
+    def test___init__(self):
+        """
+        Verify defaulting of __init__ params
+        """
+        self.assertEqual(self.up.app_id, upapi.client_id)
+        self.assertEqual(self.up.app_secret, upapi.client_secret)
+        self.assertEqual(self.up._redirect_uri, upapi.redirect_uri)
+        self.assertEqual(self.up.app_scope, upapi.scope)
 
         #
-        # Global redirect uri
+        # Override properties
         #
-        url = 'https://global.com'
-        upapi.redirect_uri = url
-        redirect_url = upapi.get_redirect_url()
-        self.assertEqual(get_redirect_param(redirect_url), url)
+        app_id = 'app_id'
+        app_secret = 'app_secret'
+        app_redirect_uri = 'app_redirect_uri'
+        app_scope = 'app_scope'
+        self.up = upapi.UpApi(
+            app_id=app_id,
+            app_secret=app_secret,
+            app_redirect_uri=app_redirect_uri,
+            app_scope=app_scope)
+        self.assertEqual(self.up.app_id, app_id)
+        self.assertEqual(self.up.app_secret, app_secret)
+        self.assertEqual(self.up._redirect_uri, app_redirect_uri)
+        self.assertEqual(self.up.app_scope, app_scope)
 
-        #
-        # Override with redirect_url
-        #
+    def test_redirect_uri(self):
+        """
+        Verify setting redirect uri updates the UpApi and oauth objects.
+        """
+        default_oauth = self.up.oauth
         url = 'https://override.com'
-        redirect_url = upapi.get_redirect_url(app_url=url)
-        self.assertEqual(get_redirect_param(redirect_url), url)
+        self.up.redirect_uri = url
+        self.assertEqual(self.up.redirect_uri, url)
+        self.assertIsNot(self.up.oauth, default_oauth)
+
+    def test_tokens(self):
+        """
+        Verify setting tokens updates the UpApi and oauth objects.
+        """
+        default_oauth = self.up.oauth
+        tokens = {'token': 'foo'}
+        self.up.tokens = tokens
+        self.assertEqual(self.up.tokens, tokens)
+        self.assertIsNot(self.up.oauth, default_oauth)
+
+    # def test_get_up_tokens(self):
+    #     default_up = self.up
+    #
+    #     TODO: mock the requests_oauthlib object
+    #
+    #     self.up.get_up_tokens()
+    #     self.assertIsNot(self.up, default_up)

--- a/test/test_UpApi.py
+++ b/test/test_UpApi.py
@@ -30,7 +30,7 @@ class FakeResponse(object):
         Fakes requests.Response
 
         :param status_code: HTTP status code of the response
-        :param raise_for_status: use this to mock the Response objects 40x/50x exception behavior
+        :param raise_for_status: use this to mock the Response object's 40x/50x exception behavior
         """
         self.status_code = status_code
         self.text = 'FakeResponse'
@@ -39,6 +39,9 @@ class FakeResponse(object):
 
 
 class TestUpApi(unittest.TestCase):
+    """
+    Unit tests for the UpApi object
+    """
     def setUp(self):
         """
         Create the UpApi object.
@@ -88,6 +91,7 @@ class TestUpApi(unittest.TestCase):
     def test__refresh_oauth(self, mock_oauth):
         """
         Verify that the OAuth2Session's auto refresh is set correctly when instantiating a new oauth object.
+        Additionally, check that the User-Agent is set correctly.
 
         :param mock_oauth: mocked OAuth2Session
         """
@@ -142,8 +146,7 @@ class TestUpApi(unittest.TestCase):
         """
         Verify the requests_oauthlib call to refresh the token and that it updates the UpApi object.
 
-        :param mock_refresh:
-        :return:
+        :param mock_refresh: mocked requests_oauthlib token refresh method
         """
         ret_token = {'access_token': 'refreshed_access'}
         mock_refresh.return_value = ret_token
@@ -158,8 +161,9 @@ class TestUpApi(unittest.TestCase):
     @mock.patch('upapi.requests_oauthlib.requests.Response.raise_for_status')
     def test_disconnect(self, mock_raise, mock_delete):
         """
-        Verify that a disconnect sets the token and oauth to None.
+        Verify that a disconnect sets the token and oauth to None, or raises the correct Exceptions.
 
+        :param mock_raise: mock OAuth lib Response function
         :param mock_delete: mock OAuth lib function
         """
         #
@@ -173,7 +177,7 @@ class TestUpApi(unittest.TestCase):
         # Non-200 and Non-40x/50x should raise from the SDK.
         #
         mock_raise.side_effect = None
-        mock_delete.return_value = FakeResponse(httplib.SEE_OTHER, raise_for_status=mock_raise)
+        mock_delete.return_value = FakeResponse(httplib.CREATED, raise_for_status=mock_raise)
         self.assertRaises(upapi.UnexpectedAPIResponse, self.up.disconnect)
 
         #
@@ -186,6 +190,9 @@ class TestUpApi(unittest.TestCase):
 
 
 class TestGetToken(unittest.TestCase):
+    """
+    Unit tests for upapi.get_token
+    """
     @mock.patch('upapi.requests_oauthlib.OAuth2Session.fetch_token', autospec=True)
     def test_get_token(self, mock_fetch_token):
         """

--- a/test/test_UpApi.py
+++ b/test/test_UpApi.py
@@ -1,0 +1,46 @@
+"""
+Unit tests for upapi.__init__
+"""
+import unittest
+import upapi
+import urlparse
+
+
+def get_redirect_param(url):
+    """
+    Retrieve the redirect_uri parameter from the URL.
+
+    :param url: URL to parse
+    :return: the redirect_uri param
+    """
+    return urlparse.parse_qs(urlparse.urlparse(url).query)['redirect_uri'][0]
+
+
+class TestGetRedirectUrl(unittest.TestCase):
+    def test_get_redirect_url(self):
+        """
+        Unit tests for upapi.get_redirect_url
+
+        :return: None
+        """
+        #
+        # Explicit redirect_url
+        #
+        url = 'https://explicit.com'
+        redirect_url = upapi.get_redirect_url(app_url=url)
+        self.assertEqual(get_redirect_param(redirect_url), url)
+
+        #
+        # Global redirect uri
+        #
+        url = 'https://global.com'
+        upapi.redirect_uri = url
+        redirect_url = upapi.get_redirect_url()
+        self.assertEqual(get_redirect_param(redirect_url), url)
+
+        #
+        # Override with redirect_url
+        #
+        url = 'https://override.com'
+        redirect_url = upapi.get_redirect_url(app_url=url)
+        self.assertEqual(get_redirect_param(redirect_url), url)

--- a/test/test_UpApi.py
+++ b/test/test_UpApi.py
@@ -229,6 +229,9 @@ class TestGetToken(unittest.TestCase):
 
 
 class TestRefreshToken(unittest.TestCase):
+    """
+    Unit tests for upapi.refresh_token
+    """
     @mock.patch('upapi.requests_oauthlib.OAuth2Session.refresh_token', autospec=True)
     def test_refresh_token(self, mock_refresh):
         """
@@ -243,6 +246,9 @@ class TestRefreshToken(unittest.TestCase):
 
 
 class TestDisconnect(unittest.TestCase):
+    """
+    Unit tests for upapi.disconnect
+    """
     @mock.patch('upapi.requests_oauthlib.OAuth2Session.delete', autospec=True)
     def test_disconnect(self, mock_delete):
         """

--- a/test/test_UpApi.py
+++ b/test/test_UpApi.py
@@ -1,8 +1,18 @@
 """
 Unit tests for upapi.__init__
 """
+import mock
 import unittest
 import upapi
+
+
+def token_saver(_):
+    """
+    Stub of a token saver method
+
+    :param _: the new token
+    """
+    pass
 
 
 class TestUpApi(unittest.TestCase):
@@ -13,7 +23,7 @@ class TestUpApi(unittest.TestCase):
         upapi.client_id = 'client_id'
         upapi.client_secret = 'client_secret'
         upapi.redirect_uri = 'redirect_uri'
-        upapi.scope = ['scope0', 'scope1']
+        upapi.scope = [upapi.SCOPES.EXTENDED_READ, upapi.SCOPES.MOVE_READ]
         self.up = upapi.UpApi()
         super(TestUpApi, self).setUp()
 
@@ -25,6 +35,8 @@ class TestUpApi(unittest.TestCase):
         self.assertEqual(self.up.app_secret, upapi.client_secret)
         self.assertEqual(self.up._redirect_uri, upapi.redirect_uri)
         self.assertEqual(self.up.app_scope, upapi.scope)
+        self.assertEqual(self.up.app_token_saver, upapi.token_saver)
+        self.assertEqual(self.up._tokens, upapi.tokens)
 
         #
         # Override properties
@@ -32,16 +44,48 @@ class TestUpApi(unittest.TestCase):
         app_id = 'app_id'
         app_secret = 'app_secret'
         app_redirect_uri = 'app_redirect_uri'
-        app_scope = 'app_scope'
+        app_scope = [upapi.SCOPES.FRIENDS_READ]
+        app_token_saver = token_saver
+        app_tokens = 'app_tokens'
         self.up = upapi.UpApi(
             app_id=app_id,
             app_secret=app_secret,
             app_redirect_uri=app_redirect_uri,
-            app_scope=app_scope)
+            app_scope=app_scope,
+            app_token_saver=app_token_saver,
+            app_tokens=app_tokens)
         self.assertEqual(self.up.app_id, app_id)
         self.assertEqual(self.up.app_secret, app_secret)
         self.assertEqual(self.up._redirect_uri, app_redirect_uri)
         self.assertEqual(self.up.app_scope, app_scope)
+        self.assertEqual(self.up.app_token_saver, app_token_saver)
+        self.assertEqual(self.up._tokens, app_tokens)
+
+    @mock.patch('upapi.requests_oauthlib.OAuth2Session', autospec=True)
+    def test__refresh_oauth(self, mock_oauth):
+        #
+        # No token saver -> no auto refresh
+        #
+        upapi.UpApi()
+        mock_oauth.assert_called_with(
+            client_id=upapi.client_id,
+            redirect_uri=upapi.redirect_uri,
+            scope=upapi.scope,
+            token=upapi.tokens)
+
+        #
+        # Token saver -> auto refresh
+        #
+        upapi.token_saver = token_saver
+        upapi.UpApi()
+        mock_oauth.assert_called_with(
+            client_id=upapi.client_id,
+            redirect_uri=upapi.redirect_uri,
+            scope=upapi.scope,
+            token=upapi.tokens,
+            auto_refresh_url='https://jawbone.com/auth/oauth2/token',
+            auto_refresh_kwargs={'client_id': upapi.client_id, 'client_secret': upapi.client_secret},
+            token_updater=upapi.token_saver)
 
     def test_redirect_uri(self):
         """
@@ -63,10 +107,33 @@ class TestUpApi(unittest.TestCase):
         self.assertEqual(self.up.tokens, tokens)
         self.assertIsNot(self.up.oauth, default_oauth)
 
-    # def test_get_up_tokens(self):
-    #     default_up = self.up
-    #
-    #     TODO: mock the requests_oauthlib object
-    #
-    #     self.up.get_up_tokens()
-    #     self.assertIsNot(self.up, default_up)
+
+class TestGetTokens(unittest.TestCase):
+    @mock.patch('upapi.requests_oauthlib.OAuth2Session.fetch_token', autospec=True)
+    def test_get_tokens(self, mock_fetch_tokens):
+        upapi.client_id = 'client_id'
+        upapi.client_secret = 'client_secret'
+        upapi.redirect_uri = 'redirect_uri'
+        upapi.scope = [upapi.SCOPES.EXTENDED_READ, upapi.SCOPES.MOVE_READ]
+
+        #
+        # No tokens because we haven't set them.
+        #
+        self.assertIsNone(upapi.tokens)
+
+        #
+        # Mock the tokens
+        #
+        mock_fetch_tokens.return_value = {
+            'access_token': 'mock_token',
+            'token_type': 'Bearer',
+            'expires_in': 31536000,
+            'refresh_token': 'mock_refresh',
+            'expires_at': 1496509667.275609}
+        upapi.get_tokens('https://localhost/foo')
+
+        #
+        # Global tokens should be set and UpApi should pick them up
+        #
+        self.assertIsNotNone(upapi.tokens)
+        self.assertEqual(upapi.UpApi().tokens, upapi.tokens)

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -12,16 +12,19 @@ import requests_oauthlib
 """
 Setting a specific User-Agent for analytics purposes.
 """
-SDK_VERSION = '1.0'
-USERAGENT = 'uapi/%s (https://developer.jawbone.com)' % SDK_VERSION
+SDK_VERSION = '0.1'
+USERAGENT = 'upapi/%s (https://developer.jawbone.com)' % SDK_VERSION
 
 
 """
-Set these variables with the values for your app from https://jawbone.com/up/developer
+Set these variables with the values for your app from https://developer.jawbone.com
 
 If you have multiple redirect URLs, you can override this redirect_uri in your API calls.
 
 If you do not specify a token_saver, upapi will not automatically refresh expired tokens.
+
+If you specify a token, the SDK will use it to establish the OAuth connection. A token refresh or disconnect
+will automatically update this variable.
 """
 client_id = None
 client_secret = None

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -59,7 +59,7 @@ def get_redirect_url(override_url=None):
 def get_tokens(callback_url):
     """
     Retrieve the OAuth tokens from the server based on the authorization code in the callback_url.
-up.
+
     :param callback_url: The URL on your server that Jawbone sent the user back to
     :return: a dictionary containing the tokens
     """
@@ -68,13 +68,15 @@ up.
     return tokens
 
 
-def get_refresh_token():
+def refresh_tokens():
     """
-    Retrieve the OAuth refresh token if you want to refresh manually.
+    Manually refresh your OAuth tokens.
 
-    :return: the refresh token
+    :return: the new tokens
     """
-    return UpApi().refresh_token
+    global tokens
+    tokens = UpApi().refresh_tokens()
+    return tokens
 
 
 class UpApi(object):
@@ -201,11 +203,12 @@ class UpApi(object):
             client_secret=self.app_secret)
         return self._tokens
 
-    @property
-    def refresh_token(self):
+    def refresh_tokens(self):
         """
-        Get the OAuth refresh token.
-
-        :return: the refresh token
+        Refresh the current OAuth token.
         """
-        return self._tokens['refresh_token']
+        self._tokens = self.oauth.refresh_token(
+            'https://jawbone.com/auth/oauth2/token',
+            client_id=self.app_id,
+            client_secret=self.app_secret)
+        return self._tokens

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -13,7 +13,7 @@ Example:
 import upapi
 upapi.client_id = ...
 
-If you have multiple redirect URLs, leave this as None and specify the redirect_uri in your API calls.
+If you have multiple redirect URLs, you can override this redirect_uri in your API calls.
 """
 client_id = None
 client_secret = None
@@ -21,16 +21,125 @@ redirect_uri = None
 scope = None
 
 
-def get_redirect_url(app_url=None):
+def get_redirect_url(override_url=None):
     """
     Get the URL to redirect new users to allow your access to your application.
 
-    :param app_url: override any globally set redirect_uri
+    :param override_url: override any globally set redirect_uri
     :return: your app-specific URL
     """
-    if app_url is None:
-        app_url = redirect_uri
-    oauth = requests_oauthlib.OAuth2Session(client_id=client_id, redirect_uri=app_url, scope=scope)
-    authorization_url, state = oauth.authorization_url('https://jawbone.com/auth/oauth2/auth')
+    authorization_url, state = UpApi(app_redirect_uri=override_url).oauth.authorization_url(
+        'https://jawbone.com/auth/oauth2/auth')
     return authorization_url
 
+
+def get_tokens(callback_url):
+    """
+    Retrieve the OAuth tokens from the server based on the authorization code in the callback_url.
+
+    :param callback_url: The URL on your server that Jawbone sent the user back to
+    :return: a dictionary containing the tokens
+    """
+    return UpApi().get_up_tokens(callback_url)
+
+
+class UpApi(object):
+    """
+    The UpApi manages the OAuth connection to the Jawbone UP API. All UP API resources are subclasses of UpApi.
+    """
+    def __init__(
+            self,
+            app_id=None,
+            app_secret=None,
+            app_redirect_uri=None,
+            app_scope=None,
+            tokens=None):
+        """
+        Create an UpApi object to manage the OAuth connection.
+
+        :param app_id: Client ID from UP developer portal
+        :param app_secret: App Secret from UP developer portal
+        :param app_redirect_uri: one of your OAuth redirect URLs
+        :param app_scope: list of permissions a user will have to approve
+        :param tokens: tokens from a previously OAuth'd user
+        """
+        if app_id is None:
+            self.app_id = client_id
+        else:
+            self.app_id = app_id
+        if app_secret is None:
+            self.app_secret = client_secret
+        else:
+            self.app_secret = app_secret
+        if app_redirect_uri is None:
+            self._redirect_uri = redirect_uri
+        else:
+            self._redirect_uri = app_redirect_uri
+        if app_scope is None:
+            self.app_scope = scope
+        else:
+            self.app_scope = app_scope
+        self._tokens = tokens
+        self.oauth = None
+        self._refresh_oauth()
+        super(UpApi, self).__init__()
+
+    def _refresh_oauth(self):
+        """
+        Get a new OAuth object. This gets called automatically when you
+        1. create the object
+        2. update the user's tokens
+        3. update the redirect_uri
+        """
+        self.oauth = requests_oauthlib.OAuth2Session(
+            client_id=self.app_id,
+            scope=self.app_scope,
+            redirect_uri=self._redirect_uri,
+            token=self.tokens)
+
+    @property
+    def redirect_uri(self):
+        """
+        An app can have multiple redirect_uris, so use this property to differentiate.
+
+        :return: the URI
+        """
+        return self._redirect_uri
+
+    @redirect_uri.setter
+    def redirect_uri(self, url):
+        """
+        Override the global redirect_uri and create a new oauth object.
+
+        :param url: the specific redirect_url for this connection
+        """
+        self._redirect_uri = url
+        self._refresh_oauth()
+
+    @property
+    def tokens(self):
+        """
+        The tokens from the OAuth handshake
+
+        :return: the tokens
+        """
+        return self._tokens
+
+    @tokens.setter
+    def tokens(self, tokens):
+        self._tokens = tokens
+        self._refresh_oauth()
+
+    def get_up_tokens(self, callback_url):
+        """
+        Retrieve a fresh set of tokens after the user has logged in and approved your app (i.e., second half of the
+        OAuth handshake).
+
+        :param callback_url: The URL on your server that Jawbone sent the user back to
+        :return: the token dictionary from the UP API
+        """
+        self._tokens = self.oauth.fetch_token(
+            'https://jawbone.com/auth/oauth2/token',
+            authorization_response=callback_url,
+            client_secret=self.app_secret)
+        return self._tokens

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -1,0 +1,36 @@
+"""
+This is the Python SDK for the Jawbone UP API.
+
+For API details: https://jawbone.com/up/developer
+For SDK details: https://github.com/Jawbone/UPPlatform_Python_SDK
+"""
+import requests_oauthlib
+
+"""
+Set these variables with the values for your app from https://jawbone.com/up/developer
+
+Example:
+import upapi
+upapi.client_id = ...
+
+If you have multiple redirect URLs, leave this as None and specify the redirect_uri in your API calls.
+"""
+client_id = None
+client_secret = None
+redirect_uri = None
+scope = None
+
+
+def get_redirect_url(app_url=None):
+    """
+    Get the URL to redirect new users to allow your access to your application.
+
+    :param app_url: override any globally set redirect_uri
+    :return: your app-specific URL
+    """
+    if app_url is None:
+        app_url = redirect_uri
+    oauth = requests_oauthlib.OAuth2Session(client_id=client_id, redirect_uri=app_url, scope=scope)
+    authorization_url, state = oauth.authorization_url('https://jawbone.com/auth/oauth2/auth')
+    return authorization_url
+

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -4,9 +4,9 @@ This is the Python SDK for the Jawbone UP API.
 For API details: https://jawbone.com/up/developer
 For SDK details: https://github.com/Jawbone/UPPlatform_Python_SDK
 """
-import endpoints
 import httplib
 import requests_oauthlib
+import upapi.endpoints
 
 
 """

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -8,6 +8,14 @@ import endpoints
 import httplib
 import requests_oauthlib
 
+
+"""
+Setting a specific User-Agent for analytics purposes.
+"""
+SDK_VERSION = '1.0'
+USERAGENT = 'uapi/%s (https://developer.jawbone.com)' % SDK_VERSION
+
+
 """
 Set these variables with the values for your app from https://jawbone.com/up/developer
 
@@ -143,6 +151,7 @@ class UpApi(object):
             redirect_uri=self._redirect_uri,
             token=self.tokens,
             **refresh_kwargs)
+        self.oauth.headers['User-Agent'] = '%s %s' % (USERAGENT, self.oauth.headers['User-Agent'])
 
     @property
     def redirect_uri(self):

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -13,7 +13,7 @@ import upapi.endpoints
 Setting a specific User-Agent for analytics purposes.
 """
 SDK_VERSION = '0.1'
-USERAGENT = 'upapi/%s (https://developer.jawbone.com)' % SDK_VERSION
+USERAGENT = 'upapi/{} (https://developer.jawbone.com)'.format(SDK_VERSION)
 
 
 """
@@ -160,7 +160,7 @@ class UpApi(object):
             redirect_uri=self._redirect_uri,
             token=self.token,
             **refresh_kwargs)
-        self.oauth.headers['User-Agent'] = '%s %s' % (USERAGENT, self.oauth.headers['User-Agent'])
+        self.oauth.headers['User-Agent'] = '{} {}'.format(USERAGENT, self.oauth.headers['User-Agent'])
 
     @property
     def redirect_uri(self):
@@ -236,7 +236,7 @@ class UpApi(object):
             # Raise an exception based on the HTTP response code
             #
             resp.raise_for_status()
-            raise UnexpectedAPIResponse('%s %s' % (resp.status_code, resp.text))
+            raise UnexpectedAPIResponse('{} {}'.format(resp.status_code, resp.text))
 
 
 class UnexpectedAPIResponse(Exception):

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -36,7 +36,7 @@ token = None
 
 def get_redirect_url(override_url=None):
     """
-    Get the URL to redirect new users to allow your access to your application.
+    Get the URL to redirect new users to where they grant access to your application.
 
     :param override_url: override any globally set redirect_uri
     :return: your app-specific URL
@@ -50,7 +50,7 @@ def get_token(callback_url):
     """
     Retrieve the OAuth token from the server based on the authorization code in the callback_url.
 
-    :param callback_url: The URL on your server that Jawbone sent the user back to
+    :param callback_url: the URL on your server that Jawbone sent the user back to
     :return: a dictionary containing the token
     """
     global token
@@ -130,6 +130,9 @@ class UpApi(object):
         else:
             self._token = app_token
 
+        #
+        # All parameters are set. Initialize the OAuth object.
+        #
         self._refresh_oauth()
         super(UpApi, self).__init__()
 
@@ -143,6 +146,9 @@ class UpApi(object):
         if self.app_token_saver is None:
             refresh_kwargs = {}
         else:
+            #
+            # Required args to auto-refresh tokens
+            #
             refresh_kwargs = {
                 'auto_refresh_url': endpoints.TOKEN,
                 'auto_refresh_kwargs': {'client_id': self.app_id, 'client_secret': self.app_secret},
@@ -186,6 +192,11 @@ class UpApi(object):
 
     @token.setter
     def token(self, new_token):
+        """
+        Update the token and the oauth object.
+
+        :param new_token: new token value
+        """
         self._token = new_token
         self._refresh_oauth()
 
@@ -194,7 +205,7 @@ class UpApi(object):
         Retrieve a token after the user has logged in and approved your app (i.e., second half of the OAuth handshake).
 
         :param callback_url: The URL on your server that Jawbone sent the user back to
-        :return: the token dictionary from the UP API
+        :return: the token from the UP API
         """
         self._token = self.oauth.fetch_token(
             endpoints.TOKEN,
@@ -221,6 +232,9 @@ class UpApi(object):
             self._token = None
             self.oauth = None
         else:
+            #
+            # Raise an exception based on the HTTP response code
+            #
             resp.raise_for_status()
             raise UnexpectedAPIResponse('%s %s' % (resp.status_code, resp.text))
 

--- a/upapi/endpoints.py
+++ b/upapi/endpoints.py
@@ -3,15 +3,15 @@ This module holds all the UP API routes used in the SDK.
 https://jawbone.com/up/developer/endpoints
 """
 DOMAIN = 'https://jawbone.com'
-AUTH_PATH = '%s/auth/oauth2' % DOMAIN
+AUTH_PATH = '{}/auth/oauth2'.format(DOMAIN)
 
 """
 OAuth Endpoints
 """
-AUTH = '%s/auth' % AUTH_PATH
-TOKEN = '%s/token' % AUTH_PATH
+AUTH = '{}/auth'.format(AUTH_PATH)
+TOKEN = '{}/token'.format(AUTH_PATH)
 
 """
 Resource Endpoints
 """
-DISCONNECT = '%s/nudge/api/v.1.0/users/@me/PartnerAppMembership' % DOMAIN
+DISCONNECT = '{}/nudge/api/v.1.0/users/@me/PartnerAppMembership'.format(DOMAIN)

--- a/upapi/endpoints.py
+++ b/upapi/endpoints.py
@@ -1,0 +1,16 @@
+"""
+This module holds all the UP API routes
+"""
+DOMAIN = 'https://jawbone.com'
+AUTH_PATH = '%s/auth/oauth2' % DOMAIN
+
+#
+# OAuth endpoints
+#
+AUTH = '%s/auth' % AUTH_PATH
+TOKEN = '%s/token' % AUTH_PATH
+
+#
+# Resource endpoints
+#
+DISCONNECT = '%s/nudge/api/v.1.0/users/@me/PartnerAppMembership' % DOMAIN

--- a/upapi/endpoints.py
+++ b/upapi/endpoints.py
@@ -1,16 +1,16 @@
 """
-This module holds all the UP API routes
+This module holds all the UP API routes used in the SDK.
 """
 DOMAIN = 'https://jawbone.com'
 AUTH_PATH = '%s/auth/oauth2' % DOMAIN
 
-#
-# OAuth endpoints
-#
+"""
+OAuth Endpoints
+"""
 AUTH = '%s/auth' % AUTH_PATH
 TOKEN = '%s/token' % AUTH_PATH
 
-#
-# Resource endpoints
-#
+"""
+Resource Endpoints
+"""
 DISCONNECT = '%s/nudge/api/v.1.0/users/@me/PartnerAppMembership' % DOMAIN

--- a/upapi/endpoints.py
+++ b/upapi/endpoints.py
@@ -1,5 +1,6 @@
 """
 This module holds all the UP API routes used in the SDK.
+https://jawbone.com/up/developer/endpoints
 """
 DOMAIN = 'https://jawbone.com'
 AUTH_PATH = '%s/auth/oauth2' % DOMAIN

--- a/upapi/scopes.py
+++ b/upapi/scopes.py
@@ -1,0 +1,21 @@
+"""
+OAuth2 scope constants for the UP API
+Refer to https://nudgestage.jawbone.com/up/developer/authentication for a definition of these scopes.
+"""
+BASIC_READ = 'basic_read'
+EXTENDED_READ = 'extended_read'
+LOCATION_READ = 'location_read'
+FRIENDS_READ = 'friends_read'
+MOOD_READ = 'mood_read'
+MOOD_WRITE = 'mood_write'
+MOVE_READ = 'move_read'
+MOVE_WRITE = 'move_write'
+SLEEP_READ = 'sleep_read'
+SLEEP_WRITE = 'sleep_write'
+MEAL_READ = 'meal_read'
+MEAL_WRITE = 'meal_write'
+WEIGHT_READ = 'weight_read'
+WEIGHT_WRITE = 'weight_write'
+GENERIC_EVENT_READ = 'generic_event_read'
+GENERIC_EVENT_WRITE = 'generic_event_write'
+HEARTRATE_READ = 'heartrate_read'

--- a/upapi/scopes.py
+++ b/upapi/scopes.py
@@ -1,6 +1,6 @@
 """
 OAuth2 scope constants for the UP API
-Refer to https://nudgestage.jawbone.com/up/developer/authentication for a definition of these scopes.
+Refer to https://jawbone.com/up/developer/authentication for a definition of these scopes.
 """
 BASIC_READ = 'basic_read'
 EXTENDED_READ = 'extended_read'


### PR DESCRIPTION
Updated the spec to reflect this PR: go/upapisdk
The README in this PR explains how to use the SDK and what's implemented so far.
