### PR TITLE
Pdr 432

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- ```upapi.set_access_token(<token>)``` and ```upapi.get_access_token()``` to replace the set/get functionality that was in ```upapi.token```.
+
+### Changed
+- Refactored the ```UpApi``` object to only initialize with credentials objects instead of tokens.
+
+### Removed
+- ```upapi.token``` no longer exists. Use ```upapi.credentials``` or the new token getter/setter functions.
+- ```upapi.token_saver``` no longer exists. You will have to save updated tokens manually.
+
 ## [0.5] - 2017-01-12
 ### Added
 - ```user.get_friends()``` to retrieve/refresh the friends list

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -217,6 +217,46 @@ class TestGetRedirectUrl(TestSystem):
         self.assert_equal(redirect_url, self.expected_url)
 
 
+class TestSetGetAccessToken(TestSystem):
+    """
+    Test upapi.set_access_token and upapi.get_access_token
+    """
+    def __init__(self):
+        super(TestSetGetAccessToken, self).__init__('upapi.set/get_access_token')
+
+    def _run(self):
+        """
+        Verify that set correctly sets the credentials object and that get returns the token.
+        """
+        #
+        # Token was already set during upapi initialization, so verify credentials
+        #
+        creds = upapi.credentials
+        self.assert_equal(creds.access_token, secrets['test_user']['token']['access_token'])
+        self.assert_equal(creds.client_id, upapi.client_id)
+        self.assert_equal(creds.client_secret, upapi.client_secret)
+        self.assert_equal(creds.refresh_token, secrets['test_user']['token']['refresh_token'])
+
+        #
+        # Expiry should match expires_in.
+        #
+        next_year = datetime.datetime.now()
+        next_year = next_year + datetime.timedelta(seconds=secrets['test_user']['token']['expires_in'])
+        self.assert_datetime_within(creds.token_expiry, expected=next_year)
+
+        self.assert_equal(creds.token_uri, secrets['web']['token_uri'])
+        self.assert_equal(creds.user_agent, upapi.base.USERAGENT)
+        self.assert_none(creds.revoke_uri)
+        self.assert_equal(creds.token_response, secrets['test_user']['token'])
+        self.assert_equal(creds.scopes, set(upapi.scope))
+        self.assert_none(creds.token_info_uri)
+
+        #
+        # Getter should give back the original token
+        #
+        self.assert_equal(upapi.get_access_token(), secrets['test_user']['token'])
+
+
 class TestRefreshToken(TestSystem):
     """
     Test upapi.refresh_token
@@ -225,20 +265,20 @@ class TestRefreshToken(TestSystem):
         """
         Grab the old token
         """
-        self.old_token = upapi.token
+        self.old_token = upapi.get_access_token()
         super(TestRefreshToken, self).__init__('upapi.refresh_token')
 
     def _run(self):
         """
         Verify token and credentials refreshed correctly.
         """
-        self.assert_none(upapi.credentials)
+        self.assert_equal(upapi.get_access_token(), secrets['test_user']['token'])
         upapi.refresh_token()
 
         #
         # Verify token
         #
-        new_token = upapi.token
+        new_token = upapi.get_access_token()
         self.assert_not_none(new_token['access_token'])
         self.assert_equal(new_token['token_type'], self.old_token['token_type'])
         self.assert_time_within(new_token['expires_in'], self.old_token['expires_in'])
@@ -313,6 +353,7 @@ class TestFriends(TestSystem):
 #
 TESTS = [
     TestGetRedirectUrl,
+    TestSetGetAccessToken,
     TestRefreshToken,
     TestUser,
     TestFriends
@@ -327,7 +368,7 @@ if __name__ == '__main__':
     upapi.client_secret = secrets['web']['client_secret']
     upapi.redirect_uri = secrets['web']['redirect_uris'][0]
     upapi.scope = [upapi.scopes.EXTENDED_READ]
-    upapi.token = secrets['test_user']['token']
+    upapi.set_access_token(secrets['test_user']['token'])
 
     #
     # Run the tests.

--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -161,7 +161,7 @@ class TestSystem(object):
         self.assert_equal(meta.user_xid, self.test_user['xid'])
         self.assert_equal(meta.message, httplib.responses[httplib.OK])
         self.assert_equal(meta.code, httplib.OK)
-        self.assert_datetime_within(meta.time)
+        self.assert_datetime_within(meta.time, window=11)
 
     def run(self):
         """
@@ -258,7 +258,7 @@ class TestRefreshToken(TestSystem):
         #
         next_year = datetime.datetime.now()
         next_year = next_year.replace(year=next_year.year + 1)
-        self.assert_datetime_within(new_creds.token_expiry, expected=next_year, window=4*60*60)
+        self.assert_datetime_within(new_creds.token_expiry, expected=next_year, window=5*60*60)
 
         self.assert_equal(new_creds.token_uri, secrets['web']['token_uri'])
         self.assert_equal(new_creds.user_agent, upapi.base.USERAGENT)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -52,7 +52,7 @@ class TestUserResource(TestResource):
                 self.app_id,
                 self.app_secret,
                 app_redirect_uri=self.app_redirect_uri,
-                user_token=self.token)
+                user_credentials=self.credentials)
 
 
 class TestSDK(unittest.TestCase):

--- a/tests/unit/test_friends.py
+++ b/tests/unit/test_friends.py
@@ -27,7 +27,7 @@ class TestFriends(tests.unit.TestResource):
             self.app_secret,
             app_redirect_uri=self.app_redirect_uri,
             app_scope=self.app_scope,
-            user_token=self.token)
+            user_credentials=self.credentials)
         mock_get.assert_called_with(friends, upapi.endpoints.USERFRIENDS)
         for index, friend in enumerate(friends.items):
             self.assertEqual(friend.xid, friends_data['items'][index]['xid'])

--- a/tests/unit/test_friends.py
+++ b/tests/unit/test_friends.py
@@ -28,7 +28,7 @@ class TestFriends(tests.unit.TestResource):
             app_redirect_uri=self.app_redirect_uri,
             app_scope=self.app_scope,
             user_token=self.token)
-        mock_get.assert_called_with(friends, upapi.endpoints.FRIENDS)
+        mock_get.assert_called_with(friends, upapi.endpoints.USERFRIENDS)
         for index, friend in enumerate(friends.items):
             self.assertEqual(friend.xid, friends_data['items'][index]['xid'])
         self.assertEqual(friends.size, friends_data['size'])

--- a/tests/unit/test_upapi.py
+++ b/tests/unit/test_upapi.py
@@ -56,9 +56,7 @@ class TestUp(tests.unit.TestSDK):
             upapi.redirect_uri,
             app_scope=upapi.scope,
             credentials_saver=upapi.credentials_saver,
-            user_credentials=upapi.credentials,
-            token_saver=upapi.token_saver,
-            user_token=upapi.token)
+            user_credentials=upapi.credentials)
 
 
 class TestGetRedirectUrl(tests.unit.TestSDK):

--- a/tests/unit/test_upapi.py
+++ b/tests/unit/test_upapi.py
@@ -173,6 +173,4 @@ class TestGetUser(tests.unit.TestSDK):
             upapi.redirect_uri,
             app_scope=upapi.scope,
             credentials_saver=upapi.credentials_saver,
-            user_credentials=upapi.credentials,
-            token_saver=upapi.token_saver,
-            user_token=upapi.token)
+            user_credentials=upapi.credentials)

--- a/tests/unit/test_upapi.py
+++ b/tests/unit/test_upapi.py
@@ -5,7 +5,36 @@ import mock
 import tests.unit
 import upapi
 import upapi.endpoints
+import upapi.exceptions
 import upapi.scopes
+
+
+class TestGetAccessToken(tests.unit.TestResource):
+
+    def test_get_access_token(self):
+        """
+        Verify access token getter.
+        """
+        #
+        # No creds, so getter should raise.
+        #
+        self.assertRaises(upapi.exceptions.MissingCredentials, upapi.get_access_token)
+
+        #
+        # Set creds and get the right token
+        #
+        upapi.credentials = self.credentials
+        self.assertEqual(upapi.get_access_token(), self.token)
+
+
+class TestSetAccessToken(tests.unit.TestSDK):
+
+    def test_set_access_token(self):
+        """
+        Verify the token is set correctly by trying to get it back.
+        """
+        upapi.set_access_token(self.token)
+        self.assertEqual(upapi.get_access_token(), self.token)
 
 
 class TestUp(tests.unit.TestSDK):

--- a/tests/unit/test_upapi.py
+++ b/tests/unit/test_upapi.py
@@ -77,14 +77,13 @@ class TestGetToken(tests.unit.TestSDK):
     @mock.patch('upapi.up', autospec=True)
     def test_get_token(self, mock_up):
         """
-        Verify that global token gets set.
+        Verify that global credentials get set.
 
         :param mock_up: mock UpApi getter
         """
         #
-        # Token and credentials not set yet.
+        # Credentials not set yet.
         #
-        self.assertIsNone(upapi.token)
         self.assertIsNone(upapi.credentials)
 
         #
@@ -97,12 +96,12 @@ class TestGetToken(tests.unit.TestSDK):
 
         #
         # Set the token and credentials. Then verify.
+        #
         callback_url = 'https://callback.url'
         token = upapi.get_token(callback_url)
         mock_up.assert_called_with()
         mock_up.return_value.get_up_token.assert_called_with(callback_url)
         self.assertEqual(token, self.token)
-        self.assertEqual(upapi.token, self.token)
         self.assertEqual(upapi.credentials, mock_up.return_value.credentials)
 
 
@@ -111,7 +110,7 @@ class TestRefreshToken(tests.unit.TestSDK):
     @mock.patch('upapi.up', autospec=True)
     def test_refresh_token(self, mock_up):
         """
-        Verify that global token gets set correctly when we refresh.
+        Verify that global credentials get set correctly when we refresh.
 
         :param mock_up: mock UpApi getter
         """
@@ -129,10 +128,10 @@ class TestRefreshToken(tests.unit.TestSDK):
         #
         # Refresh and test
         #
-        upapi.refresh_token()
+        token = upapi.refresh_token()
         mock_up.assert_called_with()
         mock_up.return_value.refresh_token.assert_called_with()
-        self.assertEqual(upapi.token, refreshed_token)
+        self.assertEqual(token, refreshed_token)
         self.assertEqual(upapi.credentials, mock_up.return_value.credentials)
 
 
@@ -141,11 +140,10 @@ class TestDisconnect(tests.unit.TestSDK):
     @mock.patch('upapi.up', autospec=True)
     def test_disconnect(self, mock_up):
         """
-        Verify that a disconnect makes the global token None.
+        Verify that a disconnect makes the global credentials None.
 
         :param mock_up: mock UpApi getter
         """
-        upapi.token = self.token
         upapi.credentials = self.credentials
 
         mock_up.return_value = mock.Mock('upapi.base.UpApi', autospec=True)
@@ -153,7 +151,6 @@ class TestDisconnect(tests.unit.TestSDK):
         upapi.disconnect()
         mock_up.assert_called_with()
         mock_up.return_value.disconnect.assert_called_with()
-        self.assertIsNone(upapi.token)
         self.assertIsNone(upapi.credentials)
 
 

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -22,7 +22,7 @@ class TestUser(tests.unit.TestUserResource):
             self.app_id,
             self.app_secret,
             app_redirect_uri=self.app_redirect_uri,
-            user_token=self.token)
+            user_credentials=self.credentials)
         mock_get.assert_called_with(user, upapi.endpoints.USER)
         self.assertEqual(user.first, user_data['first'])
         self.assertEqual(user.last, user_data['last'])

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -39,9 +39,7 @@ def up():
         redirect_uri,
         app_scope=scope,
         credentials_saver=credentials_saver,
-        user_credentials=credentials,
-        token_saver=token_saver,
-        user_token=token)
+        user_credentials=credentials)
 
 
 """

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -5,6 +5,7 @@ For API details: https://jawbone.com/up/developer
 For SDK details: https://github.com/Jawbone/UPPlatform_Python_SDK
 """
 import upapi.endpoints
+import upapi.exceptions
 import upapi.base
 import upapi.user
 
@@ -22,8 +23,8 @@ redirect_uri = None
 scope = None
 credentials_saver = None
 credentials = None
-token_saver = None
 token = None
+token_saver = None
 
 
 def up():
@@ -41,6 +42,46 @@ def up():
         user_credentials=credentials,
         token_saver=token_saver,
         user_token=token)
+
+
+"""
+upapi stores access tokens as Credentials objects. If you prefer to use the access tokens returned from the UP OAuth
+flow, use these functions to:
+- get the currently set user's access token from the Credentials object
+- set the current user's access token (and in turn the Credentials object)
+"""
+
+
+def get_access_token():
+    """
+    Convert the current Credentials object into an access token.
+
+    :return: the access token
+    """
+    if credentials is None:
+        raise upapi.exceptions.MissingCredentials('No credentials to convert into a token.')
+    return credentials.token_response
+
+
+def set_access_token(access_token):
+    """
+    Convert the token to a credentials object and set it.
+
+    :param access_token: access token
+    """
+    global credentials
+    credentials = up().token_to_creds(access_token)
+
+
+"""
+The following functions are meant to help automate the OAuth flow.
+1. Send the user to the value of get_redirect_url()
+2. Have your callback handler call get_token() with it's URL
+
+When the token expires call refresh_token().
+
+When the user wants to be removed from your app, call disconnect().
+"""
 
 
 def get_redirect_url():
@@ -79,6 +120,21 @@ def refresh_token():
     return token
 
 
+def disconnect():
+    """
+    Revoke the API access for this user.
+    """
+    up().disconnect()
+    global token, credentials
+    token = None
+    credentials = None
+
+
+"""
+The following functions are helpers for accessing upapi objects (i.e., API resources).
+"""
+
+
 def get_user():
     """
     Create a User object with the global properties.
@@ -94,13 +150,3 @@ def get_user():
         user_credentials=credentials,
         token_saver=token_saver,
         user_token=token)
-
-
-def disconnect():
-    """
-    Revoke the API access for this user.
-    """
-    up().disconnect()
-    global token, credentials
-    token = None
-    credentials = None

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -14,8 +14,11 @@ Set these variables with the values for your app from https://developer.jawbone.
 
 If you have multiple redirect URLs, you can change this value as needed.
 
-If you specify a credentials object or a token, the SDK will use it to establish the OAuth connection. Manually
-refreshing the token or disconnecting will automatically update these variables.
+If you specify a credentials object, the SDK will use it to establish the OAuth connection. Manually
+refreshing the token or disconnecting will automatically update the credentials variable.
+
+If you only have an access token and not a credentials object, you can use set_access_token, which will set the
+credentials variable from that token.
 """
 client_id = None
 client_secret = None
@@ -23,8 +26,6 @@ redirect_uri = None
 scope = None
 credentials_saver = None
 credentials = None
-token = None
-token_saver = None
 
 
 def up():
@@ -94,11 +95,12 @@ def get_redirect_url():
 def get_token(callback_url):
     """
     Retrieve the OAuth token from the server based on the authorization code in the callback_url.
+    This function returns the access token, and it sets the upapi.credentials object.
 
     :param callback_url: the URL on your server that Jawbone sent the user back to
     :return: a dictionary containing the token
     """
-    global token, credentials
+    global credentials
     my_up = up()
     token = my_up.get_up_token(callback_url)
     credentials = my_up.credentials
@@ -111,7 +113,7 @@ def refresh_token():
 
     :return: the new token
     """
-    global token, credentials
+    global credentials
     my_up = up()
     token = my_up.refresh_token()
     credentials = my_up.credentials
@@ -123,8 +125,7 @@ def disconnect():
     Revoke the API access for this user.
     """
     up().disconnect()
-    global token, credentials
-    token = None
+    global credentials
     credentials = None
 
 

--- a/upapi/__init__.py
+++ b/upapi/__init__.py
@@ -145,6 +145,4 @@ def get_user():
         redirect_uri,
         app_scope=scope,
         credentials_saver=credentials_saver,
-        user_credentials=credentials,
-        token_saver=token_saver,
-        user_token=token)
+        user_credentials=credentials)

--- a/upapi/base.py
+++ b/upapi/base.py
@@ -8,6 +8,7 @@ import json
 import oauth2client.client
 import upapi.endpoints
 import upapi.exceptions
+import upapi.meta
 import upapi.scopes
 import urllib
 import urlparse
@@ -16,7 +17,7 @@ import urlparse
 """
 Setting a specific User-Agent for analytics purposes.
 """
-SDK_VERSION = '0.5'
+SDK_VERSION = '0.6'
 USERAGENT = 'upapi/{} (https://developer.jawbone.com)'.format(SDK_VERSION)
 
 

--- a/upapi/endpoints.py
+++ b/upapi/endpoints.py
@@ -16,7 +16,49 @@ Resource Endpoints
 """
 VERSION = 'v.1.1'
 RESOURCE = '{}/nudge/api/{}'.format(DOMAIN, VERSION)
+
+"""
+User-specific resources
+"""
 USER = '{}/users/@me'.format(RESOURCE)
-FRIENDS = '{}/friends'.format(USER)
+USERBANDEVENTS = '{}/bandevents'.format(USER)
+USERBODYEVENTS = '{}/body_events'.format(USER)
+USERHEARTRATES = '{}/heartrates'.format(USER)
+USERGENERIC = '{}/generic_events'.format(USER)
+USERGOALS = '{}/goals'.format(USER)
+USERMEALS = '{}/meals'.format(USER)
+USERMOODS = '{}/mood'.format(USER)
+USERMOVES = '{}/moves'.format(USER)
+USERREFRESH = '{}/refreshToken'.format(USER)
+USERSETTINGS = '{}/settings'.format(USER)
+USERSLEEPS = '{}/sleeps'.format(USER)
+USERTIMEZONE = '{}/timezone'.format(USER)
+USERTRENDS = '{}/trends'.format(USER)
+USERFRIENDS = '{}/friends'.format(USER)
+USERWORKOUTS = '{}/workouts'.format(USER)
 PUBSUB = '{}/pubsub'.format(USER)
 DISCONNECT = '{}/PartnerAppMembership'.format(USER)
+
+"""
+Data-specific resources
+"""
+XID = '{xid}'
+UPDATE = '/partialUpdate'
+GRAPH = '/image'
+TICKS = '/ticks'
+BODYEVENTS = '{}/body_events/{}'.format(RESOURCE, XID)
+GENERICEVENTS = '{}/generic_events/{}'.format(RESOURCE, XID)
+GENERICUPDATE = '{}{}'.format(GENERICEVENTS, UPDATE)
+MEALS = '{}/meals/{}'.format(RESOURCE, XID)
+MEALSUPDATE = '{}{}'.format(MEALS, UPDATE)
+MOODS = '{}/mood/{}'.format(RESOURCE, XID)
+MOVES = '{}/moves/{}'.format(RESOURCE, XID)
+MOVESGRAPH = '{}{}'.format(MOVES, GRAPH)
+MOVESTICKS = '{}{}'.format(MOVES, TICKS)
+SLEEPS = '{}/sleeps/{}'.format(RESOURCE, XID)
+SLEEPSGRAPH = '{}{}'.format(SLEEPS, GRAPH)
+SLEEPSPHASES = '{}{}'.format(SLEEPS, TICKS)
+WORKOUTS = '{}/workouts/{}'.format(RESOURCE, XID)
+WORKOUTSGRAPH = '{}{}'.format(WORKOUTS, GRAPH)
+WORKOUTSTICKS = '{}{}'.format(WORKOUTS, TICKS)
+WORKOUTSUPDATE = '{}{}'.format(WORKOUTS, UPDATE)

--- a/upapi/exceptions.py
+++ b/upapi/exceptions.py
@@ -8,3 +8,10 @@ class UnexpectedAPIResponse(Exception):
     UpApi raises this for API responses other than expected (according to the documentation)
     """
     pass
+
+
+class MissingCredentials(Exception):
+    """
+    Raised when trying to act on behalf of the user without setting the Credentials object.
+    """
+    pass

--- a/upapi/user/friends.py
+++ b/upapi/user/friends.py
@@ -11,7 +11,7 @@ class Friends(upapi.base.UpApi):
     """
     def __init__(self, *args, **kwargs):
         super(Friends, self).__init__(*args, **kwargs)
-        friends_data = self.get(upapi.endpoints.FRIENDS)
+        friends_data = self.get(upapi.endpoints.USERFRIENDS)
         self.items = []
         for item in friends_data['items']:
             self.items.append(Friend(item))


### PR DESCRIPTION
Removed upapi.token in favor of upapi.credentials.
Refactored UpApi to only use credentials.
Created upapi.set_access_token and upapi.get_access_token helper functions